### PR TITLE
Add test/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+test/
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
The test/ directory is now ignored to prevent test files from being tracked in version control.